### PR TITLE
feat(model schema): Adding samples of the Model schema for energy models

### DIFF
--- a/app/models/samples/json/model_multi_zone_single_family_house.json
+++ b/app/models/samples/json/model_multi_zone_single_family_house.json
@@ -1,0 +1,1659 @@
+{
+    "type": "Model",
+    "name": "MultiZoneSingleFamilyHouse",
+    "name_original": "Multi Zone Single Family House",
+    "properties": {
+        "type": "ModelProperties",
+        "energy": {
+            "type": "ModelEnergyProperties",
+            "global_construction_set": {
+                "type": "ConstructionSetAbridged",
+                "name": "Default Generic Construction Set",
+                "wall_set": {
+                    "type": "WallSetAbridged",
+                    "exterior_construction": "Generic Exterior Brick Wall",
+                    "interior_construction": "Generic Interior Wall",
+                    "ground_construction": "Generic Underground Wall"
+                },
+                "floor_set": {
+                    "type": "FloorSetAbridged",
+                    "exterior_construction": "Generic Exposed Floor Slab",
+                    "interior_construction": "Generic Interior Floor",
+                    "ground_construction": "Generic Ground Slab"
+                },
+                "roof_ceiling_set": {
+                    "type": "RoofCeilingSetAbridged",
+                    "exterior_construction": "Generic Roof",
+                    "interior_construction": "Generic Interior Ceiling",
+                    "ground_construction": "Generic Underground Roof"
+                },
+                "aperture_set": {
+                    "type": "ApertureSetAbridged",
+                    "fixed_window_construction": "Generic Double Pane Window",
+                    "interior_construction": "Generic Single Pane Window",
+                    "skylight_construction": "Generic Double Pane Window",
+                    "operable_window_construction": "Generic Double Pane Window",
+                    "glass_door_construction": "Generic Double Pane Window"
+                },
+                "door_set": {
+                    "type": "DoorSetAbridged",
+                    "exterior_construction": "Generic Exterior Door",
+                    "interior_construction": "Generic Interior Door",
+                    "overhead_construction": "Generic Exterior Door"
+                }
+            },
+            "construction_sets": [
+                {
+                    "type": "ConstructionSetAbridged",
+                    "name": "Attic Construction Set",
+                    "wall_set": {
+                        "type": "WallSetAbridged",
+                        "exterior_construction": null,
+                        "interior_construction": null,
+                        "ground_construction": null
+                    },
+                    "floor_set": {
+                        "type": "FloorSetAbridged",
+                        "exterior_construction": null,
+                        "interior_construction": "Attic Floor Construction",
+                        "ground_construction": null
+                    },
+                    "roof_ceiling_set": {
+                        "type": "RoofCeilingSetAbridged",
+                        "exterior_construction": "Attic Roof Construction",
+                        "interior_construction": null,
+                        "ground_construction": null
+                    },
+                    "aperture_set": {
+                        "type": "ApertureSetAbridged",
+                        "fixed_window_construction": null,
+                        "interior_construction": null,
+                        "skylight_construction": null,
+                        "operable_window_construction": null,
+                        "glass_door_construction": null
+                    },
+                    "door_set": {
+                        "type": "DoorSetAbridged",
+                        "exterior_construction": null,
+                        "interior_construction": null,
+                        "overhead_construction": null
+                    }
+                }
+            ],
+            "constructions": [
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "name": "Generic Underground Roof",
+                    "layers": [
+                        "Generic 50mm Insulation Board",
+                        "Generic Heavyweight Concrete",
+                        "Generic Ceiling Air Gap",
+                        "Generic Acoustic Tile"
+                    ]
+                },
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "name": "Generic Interior Floor",
+                    "layers": [
+                        "Generic Acoustic Tile",
+                        "Generic Ceiling Air Gap",
+                        "Generic Lightweight Concrete"
+                    ]
+                },
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "name": "Generic Interior Ceiling",
+                    "layers": [
+                        "Generic Lightweight Concrete",
+                        "Generic Ceiling Air Gap",
+                        "Generic Acoustic Tile"
+                    ]
+                },
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "name": "Generic Roof",
+                    "layers": [
+                        "Generic Roof Membrane",
+                        "Generic 50mm Insulation Board",
+                        "Generic Lightweight Concrete",
+                        "Generic Ceiling Air Gap",
+                        "Generic Acoustic Tile"
+                    ]
+                },
+                {
+                    "type": "WindowConstructionAbridged",
+                    "name": "Generic Single Pane Window",
+                    "layers": [
+                        "Generic Clear Glass"
+                    ]
+                },
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "name": "Generic Exposed Floor Slab",
+                    "layers": [
+                        "Generic Metal Surface",
+                        "Generic Ceiling Air Gap",
+                        "Generic 50mm Insulation Board",
+                        "Generic Lightweight Concrete"
+                    ]
+                },
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "name": "Generic Underground Wall",
+                    "layers": [
+                        "Generic 50mm Insulation Board",
+                        "Generic Heavyweight Concrete"
+                    ]
+                },
+                {
+                    "type": "WindowConstructionAbridged",
+                    "name": "Generic Double Pane Window",
+                    "layers": [
+                        "Generic Clear Glass",
+                        "Generic Window Air Gap",
+                        "Generic Clear Glass"
+                    ]
+                },
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "name": "Generic Interior Wall",
+                    "layers": [
+                        "Generic Gypsum Board",
+                        "Generic Wall Air Gap",
+                        "Generic Gypsum Board"
+                    ]
+                },
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "name": "Attic Roof Construction",
+                    "layers": [
+                        "Generic Roof Membrane",
+                        "PolyIso",
+                        "Generic 25mm Wood"
+                    ]
+                },
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "name": "Generic Ground Slab",
+                    "layers": [
+                        "Generic 50mm Insulation Board",
+                        "Generic Heavyweight Concrete"
+                    ]
+                },
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "name": "Generic Interior Door",
+                    "layers": [
+                        "Generic 25mm Wood"
+                    ]
+                },
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "name": "Attic Floor Construction",
+                    "layers": [
+                        "Generic 25mm Wood",
+                        "Generic 50mm Insulation Board",
+                        "Generic 25mm Wood"
+                    ]
+                },
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "name": "Generic Exterior Door",
+                    "layers": [
+                        "Generic Metal Surface",
+                        "Generic 25mm Insulation Board",
+                        "Generic Metal Surface"
+                    ]
+                },
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "name": "Generic Exterior Brick Wall",
+                    "layers": [
+                        "Generic Brick",
+                        "Generic Lightweight Concrete",
+                        "Generic 50mm Insulation Board",
+                        "Generic Wall Air Gap",
+                        "Generic Gypsum Board"
+                    ]
+                }
+            ],
+            "materials": [
+                {
+                    "type": "EnergyMaterial",
+                    "name": "Generic Brick",
+                    "roughness": "MediumRough",
+                    "thickness": 0.1,
+                    "conductivity": 0.9,
+                    "density": 1920.0,
+                    "specific_heat": 790.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.7,
+                    "visible_absorptance": 0.7
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "name": "Generic Ceiling Air Gap",
+                    "roughness": "Smooth",
+                    "thickness": 0.1,
+                    "conductivity": 0.556,
+                    "density": 1.28,
+                    "specific_heat": 1000.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.7,
+                    "visible_absorptance": 0.7
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "name": "Generic Metal Surface",
+                    "roughness": "Smooth",
+                    "thickness": 0.0015,
+                    "conductivity": 45.0,
+                    "density": 7690.0,
+                    "specific_heat": 410.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.5,
+                    "visible_absorptance": 0.5
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "name": "Generic Lightweight Concrete",
+                    "roughness": "MediumRough",
+                    "thickness": 0.1,
+                    "conductivity": 0.53,
+                    "density": 1280.0,
+                    "specific_heat": 840.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.8,
+                    "visible_absorptance": 0.8
+                },
+                {
+                    "type": "EnergyWindowMaterialGlazing",
+                    "name": "Generic Clear Glass",
+                    "thickness": 0.006,
+                    "solar_transmittance": 0.771,
+                    "solar_reflectance": 0.07,
+                    "solar_reflectance_back": 0.07,
+                    "visible_transmittance": 0.884,
+                    "visible_reflectance": 0.0804,
+                    "visible_reflectance_back": 0.0804,
+                    "infrared_transmittance": 0.0,
+                    "emissivity": 0.84,
+                    "emissivity_back": 0.84,
+                    "conductivity": 1.0,
+                    "dirt_correction": 1.0,
+                    "solar_diffusing": false
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "name": "Generic Gypsum Board",
+                    "roughness": "MediumSmooth",
+                    "thickness": 0.0127,
+                    "conductivity": 0.16,
+                    "density": 800.0,
+                    "specific_heat": 1090.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.5,
+                    "visible_absorptance": 0.5
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "name": "Generic Wall Air Gap",
+                    "roughness": "Smooth",
+                    "thickness": 0.1,
+                    "conductivity": 0.667,
+                    "density": 1.28,
+                    "specific_heat": 1000.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.7,
+                    "visible_absorptance": 0.7
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "name": "Generic 50mm Insulation Board",
+                    "roughness": "MediumRough",
+                    "thickness": 0.05,
+                    "conductivity": 0.03,
+                    "density": 43.0,
+                    "specific_heat": 1210.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.7,
+                    "visible_absorptance": 0.7
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "name": "Generic 25mm Wood",
+                    "roughness": "MediumSmooth",
+                    "thickness": 0.0254,
+                    "conductivity": 0.15,
+                    "density": 608.0,
+                    "specific_heat": 1630.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.5,
+                    "visible_absorptance": 0.5
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "name": "Generic Acoustic Tile",
+                    "roughness": "MediumSmooth",
+                    "thickness": 0.02,
+                    "conductivity": 0.06,
+                    "density": 368.0,
+                    "specific_heat": 590.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.3,
+                    "visible_absorptance": 0.3
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "name": "PolyIso",
+                    "roughness": "MediumRough",
+                    "thickness": 0.2,
+                    "conductivity": 0.03,
+                    "density": 43.0,
+                    "specific_heat": 1210.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.7,
+                    "visible_absorptance": 0.7
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "name": "Generic 25mm Insulation Board",
+                    "roughness": "MediumRough",
+                    "thickness": 0.05,
+                    "conductivity": 0.03,
+                    "density": 43.0,
+                    "specific_heat": 1210.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.7,
+                    "visible_absorptance": 0.7
+                },
+                {
+                    "type": "EnergyWindowMaterialGas",
+                    "name": "Generic Window Air Gap",
+                    "thickness": 0.0127,
+                    "gas_type": "Air"
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "name": "Generic Roof Membrane",
+                    "roughness": "MediumRough",
+                    "thickness": 0.01,
+                    "conductivity": 0.16,
+                    "density": 1120.0,
+                    "specific_heat": 1460.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.7,
+                    "visible_absorptance": 0.7
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "name": "Generic Heavyweight Concrete",
+                    "roughness": "MediumRough",
+                    "thickness": 0.2,
+                    "conductivity": 1.95,
+                    "density": 2240.0,
+                    "specific_heat": 900.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.8,
+                    "visible_absorptance": 0.8
+                }
+            ]
+        }
+    },
+    "rooms": [
+        {
+            "type": "RoomAbridged",
+            "name": "FirstFloor",
+            "name_original": "First Floor",
+            "properties": {
+                "type": "RoomProperties",
+                "energy": {
+                    "type": "RoomEnergyPropertiesAbridged",
+                    "program_type": null,
+                    "construction_set": null,
+                    "people": null,
+                    "lighting": null,
+                    "electric_equipment": null,
+                    "gas_equipment": null,
+                    "infiltration": null,
+                    "ventilation": null
+                }
+            },
+            "faces": [
+                "FirstFloor_Bottom",
+                "FirstFloor_Front",
+                "FirstFloor_Right",
+                "FirstFloor_Back",
+                "FirstFloor_Left",
+                "FirstFloor_Top"
+            ]
+        },
+        {
+            "type": "RoomAbridged",
+            "name": "SecondFloor",
+            "name_original": "Second Floor",
+            "properties": {
+                "type": "RoomProperties",
+                "energy": {
+                    "type": "RoomEnergyPropertiesAbridged",
+                    "program_type": null,
+                    "construction_set": null,
+                    "people": null,
+                    "lighting": null,
+                    "electric_equipment": null,
+                    "gas_equipment": null,
+                    "infiltration": null,
+                    "ventilation": null
+                }
+            },
+            "faces": [
+                "SecondFloor_Bottom",
+                "SecondFloor_Front",
+                "SecondFloor_Right",
+                "SecondFloor_Back",
+                "SecondFloor_Left",
+                "SecondFloor_Top"
+            ]
+        },
+        {
+            "type": "RoomAbridged",
+            "name": "Attic",
+            "name_original": "Attic",
+            "properties": {
+                "type": "RoomProperties",
+                "energy": {
+                    "type": "RoomEnergyPropertiesAbridged",
+                    "program_type": null,
+                    "construction_set": "Attic Construction Set",
+                    "people": null,
+                    "lighting": null,
+                    "electric_equipment": null,
+                    "gas_equipment": null,
+                    "infiltration": null,
+                    "ventilation": null
+                }
+            },
+            "faces": [
+                "AtticFace1",
+                "AtticFace2",
+                "AtticFace3",
+                "AtticFace4",
+                "AtticFace5"
+            ]
+        }
+    ],
+    "faces": [
+        {
+            "type": "FaceAbridged",
+            "name": "FirstFloor_Bottom",
+            "name_original": "First Floor_Bottom",
+            "geometry": {
+                "type": "Face3D",
+                "boundary": [
+                    [
+                        0.0,
+                        0.0,
+                        0.0
+                    ],
+                    [
+                        0.0,
+                        10.0,
+                        0.0
+                    ],
+                    [
+                        10.0,
+                        10.0,
+                        0.0
+                    ],
+                    [
+                        10.0,
+                        0.0,
+                        0.0
+                    ]
+                ]
+            },
+            "properties": {
+                "type": "FaceProperties",
+                "energy": {
+                    "type": "FaceEnergyPropertiesAbridged"
+                }
+            },
+            "face_type": {
+                "type": "Floor"
+            },
+            "boundary_condition": {
+                "type": "Ground",
+                "sun_exposure": "NoSun",
+                "wind_exposure": "NoWind",
+                "view_factor": "autocalculate"
+            },
+            "parent": "FirstFloor"
+        },
+        {
+            "type": "FaceAbridged",
+            "name": "FirstFloor_Front",
+            "name_original": "First Floor_Front",
+            "geometry": {
+                "type": "Face3D",
+                "boundary": [
+                    [
+                        10.0,
+                        10.0,
+                        0.0
+                    ],
+                    [
+                        0.0,
+                        10.0,
+                        0.0
+                    ],
+                    [
+                        0.0,
+                        10.0,
+                        3.0
+                    ],
+                    [
+                        10.0,
+                        10.0,
+                        3.0
+                    ]
+                ]
+            },
+            "properties": {
+                "type": "FaceProperties",
+                "energy": {
+                    "type": "FaceEnergyPropertiesAbridged"
+                }
+            },
+            "face_type": {
+                "type": "Wall"
+            },
+            "boundary_condition": {
+                "type": "Outdoors",
+                "sun_exposure": "SunExposed",
+                "wind_exposure": "WindExposed",
+                "view_factor": "autocalculate"
+            },
+            "parent": "FirstFloor",
+            "apertures": [
+                "FirstFloor_Front_Glz0"
+            ]
+        },
+        {
+            "type": "FaceAbridged",
+            "name": "FirstFloor_Right",
+            "name_original": "First Floor_Right",
+            "geometry": {
+                "type": "Face3D",
+                "boundary": [
+                    [
+                        10.0,
+                        10.0,
+                        3.0
+                    ],
+                    [
+                        10.0,
+                        0.0,
+                        3.0
+                    ],
+                    [
+                        10.0,
+                        0.0,
+                        0.0
+                    ],
+                    [
+                        10.0,
+                        10.0,
+                        0.0
+                    ]
+                ]
+            },
+            "properties": {
+                "type": "FaceProperties",
+                "energy": {
+                    "type": "FaceEnergyPropertiesAbridged"
+                }
+            },
+            "face_type": {
+                "type": "Wall"
+            },
+            "boundary_condition": {
+                "type": "Outdoors",
+                "sun_exposure": "SunExposed",
+                "wind_exposure": "WindExposed",
+                "view_factor": "autocalculate"
+            },
+            "parent": "FirstFloor",
+            "apertures": [
+                "FirstFloor_Right_Glz0"
+            ]
+        },
+        {
+            "type": "FaceAbridged",
+            "name": "FirstFloor_Back",
+            "name_original": "First Floor_Back",
+            "geometry": {
+                "type": "Face3D",
+                "boundary": [
+                    [
+                        0.0,
+                        0.0,
+                        0.0
+                    ],
+                    [
+                        10.0,
+                        0.0,
+                        0.0
+                    ],
+                    [
+                        10.0,
+                        0.0,
+                        3.0
+                    ],
+                    [
+                        0.0,
+                        0.0,
+                        3.0
+                    ]
+                ]
+            },
+            "properties": {
+                "type": "FaceProperties",
+                "energy": {
+                    "type": "FaceEnergyPropertiesAbridged"
+                }
+            },
+            "face_type": {
+                "type": "Wall"
+            },
+            "boundary_condition": {
+                "type": "Outdoors",
+                "sun_exposure": "SunExposed",
+                "wind_exposure": "WindExposed",
+                "view_factor": "autocalculate"
+            },
+            "parent": "FirstFloor",
+            "apertures": [
+                "FirstFloor_Back_Glz0"
+            ]
+        },
+        {
+            "type": "FaceAbridged",
+            "name": "FirstFloor_Left",
+            "name_original": "First Floor_Left",
+            "geometry": {
+                "type": "Face3D",
+                "boundary": [
+                    [
+                        0.0,
+                        0.0,
+                        0.0
+                    ],
+                    [
+                        0.0,
+                        0.0,
+                        3.0
+                    ],
+                    [
+                        0.0,
+                        10.0,
+                        3.0
+                    ],
+                    [
+                        0.0,
+                        10.0,
+                        0.0
+                    ]
+                ]
+            },
+            "properties": {
+                "type": "FaceProperties",
+                "energy": {
+                    "type": "FaceEnergyPropertiesAbridged"
+                }
+            },
+            "face_type": {
+                "type": "Wall"
+            },
+            "boundary_condition": {
+                "type": "Outdoors",
+                "sun_exposure": "SunExposed",
+                "wind_exposure": "WindExposed",
+                "view_factor": "autocalculate"
+            },
+            "parent": "FirstFloor",
+            "apertures": [
+                "FirstFloor_Left_Glz0"
+            ]
+        },
+        {
+            "type": "FaceAbridged",
+            "name": "FirstFloor_Top",
+            "name_original": "First Floor_Top",
+            "geometry": {
+                "type": "Face3D",
+                "boundary": [
+                    [
+                        10.0,
+                        0.0,
+                        3.0
+                    ],
+                    [
+                        10.0,
+                        10.0,
+                        3.0
+                    ],
+                    [
+                        0.0,
+                        10.0,
+                        3.0
+                    ],
+                    [
+                        0.0,
+                        0.0,
+                        3.0
+                    ]
+                ]
+            },
+            "properties": {
+                "type": "FaceProperties",
+                "energy": {
+                    "type": "FaceEnergyPropertiesAbridged"
+                }
+            },
+            "face_type": {
+                "type": "RoofCeiling"
+            },
+            "boundary_condition": {
+                "type": "Surface",
+                "sun_exposure": "NoSun",
+                "wind_exposure": "NoWind",
+                "view_factor": "autocalculate",
+                "bc_object": "SecondFloor_Bottom"
+            },
+            "parent": "FirstFloor"
+        },
+        {
+            "type": "FaceAbridged",
+            "name": "SecondFloor_Bottom",
+            "name_original": "Second Floor_Bottom",
+            "geometry": {
+                "type": "Face3D",
+                "boundary": [
+                    [
+                        0.0,
+                        0.0,
+                        3.0
+                    ],
+                    [
+                        0.0,
+                        10.0,
+                        3.0
+                    ],
+                    [
+                        10.0,
+                        10.0,
+                        3.0
+                    ],
+                    [
+                        10.0,
+                        0.0,
+                        3.0
+                    ]
+                ]
+            },
+            "properties": {
+                "type": "FaceProperties",
+                "energy": {
+                    "type": "FaceEnergyPropertiesAbridged"
+                }
+            },
+            "face_type": {
+                "type": "Floor"
+            },
+            "boundary_condition": {
+                "type": "Surface",
+                "sun_exposure": "NoSun",
+                "wind_exposure": "NoWind",
+                "view_factor": "autocalculate",
+                "bc_object": "FirstFloor_Top"
+            },
+            "parent": "SecondFloor"
+        },
+        {
+            "type": "FaceAbridged",
+            "name": "SecondFloor_Front",
+            "name_original": "Second Floor_Front",
+            "geometry": {
+                "type": "Face3D",
+                "boundary": [
+                    [
+                        10.0,
+                        10.0,
+                        3.0
+                    ],
+                    [
+                        0.0,
+                        10.0,
+                        3.0
+                    ],
+                    [
+                        0.0,
+                        10.0,
+                        6.0
+                    ],
+                    [
+                        10.0,
+                        10.0,
+                        6.0
+                    ]
+                ]
+            },
+            "properties": {
+                "type": "FaceProperties",
+                "energy": {
+                    "type": "FaceEnergyPropertiesAbridged"
+                }
+            },
+            "face_type": {
+                "type": "Wall"
+            },
+            "boundary_condition": {
+                "type": "Outdoors",
+                "sun_exposure": "SunExposed",
+                "wind_exposure": "WindExposed",
+                "view_factor": "autocalculate"
+            },
+            "parent": "SecondFloor",
+            "apertures": [
+                "SecondFloor_Front_Glz0"
+            ]
+        },
+        {
+            "type": "FaceAbridged",
+            "name": "SecondFloor_Right",
+            "name_original": "Second Floor_Right",
+            "geometry": {
+                "type": "Face3D",
+                "boundary": [
+                    [
+                        10.0,
+                        10.0,
+                        6.0
+                    ],
+                    [
+                        10.0,
+                        0.0,
+                        6.0
+                    ],
+                    [
+                        10.0,
+                        0.0,
+                        3.0
+                    ],
+                    [
+                        10.0,
+                        10.0,
+                        3.0
+                    ]
+                ]
+            },
+            "properties": {
+                "type": "FaceProperties",
+                "energy": {
+                    "type": "FaceEnergyPropertiesAbridged"
+                }
+            },
+            "face_type": {
+                "type": "Wall"
+            },
+            "boundary_condition": {
+                "type": "Outdoors",
+                "sun_exposure": "SunExposed",
+                "wind_exposure": "WindExposed",
+                "view_factor": "autocalculate"
+            },
+            "parent": "SecondFloor",
+            "apertures": [
+                "SecondFloor_Right_Glz0"
+            ]
+        },
+        {
+            "type": "FaceAbridged",
+            "name": "SecondFloor_Back",
+            "name_original": "Second Floor_Back",
+            "geometry": {
+                "type": "Face3D",
+                "boundary": [
+                    [
+                        0.0,
+                        0.0,
+                        3.0
+                    ],
+                    [
+                        10.0,
+                        0.0,
+                        3.0
+                    ],
+                    [
+                        10.0,
+                        0.0,
+                        6.0
+                    ],
+                    [
+                        0.0,
+                        0.0,
+                        6.0
+                    ]
+                ]
+            },
+            "properties": {
+                "type": "FaceProperties",
+                "energy": {
+                    "type": "FaceEnergyPropertiesAbridged"
+                }
+            },
+            "face_type": {
+                "type": "Wall"
+            },
+            "boundary_condition": {
+                "type": "Outdoors",
+                "sun_exposure": "SunExposed",
+                "wind_exposure": "WindExposed",
+                "view_factor": "autocalculate"
+            },
+            "parent": "SecondFloor",
+            "apertures": [
+                "SecondFloor_Back_Glz0"
+            ]
+        },
+        {
+            "type": "FaceAbridged",
+            "name": "SecondFloor_Left",
+            "name_original": "Second Floor_Left",
+            "geometry": {
+                "type": "Face3D",
+                "boundary": [
+                    [
+                        0.0,
+                        0.0,
+                        3.0
+                    ],
+                    [
+                        0.0,
+                        0.0,
+                        6.0
+                    ],
+                    [
+                        0.0,
+                        10.0,
+                        6.0
+                    ],
+                    [
+                        0.0,
+                        10.0,
+                        3.0
+                    ]
+                ]
+            },
+            "properties": {
+                "type": "FaceProperties",
+                "energy": {
+                    "type": "FaceEnergyPropertiesAbridged"
+                }
+            },
+            "face_type": {
+                "type": "Wall"
+            },
+            "boundary_condition": {
+                "type": "Outdoors",
+                "sun_exposure": "SunExposed",
+                "wind_exposure": "WindExposed",
+                "view_factor": "autocalculate"
+            },
+            "parent": "SecondFloor",
+            "apertures": [
+                "SecondFloor_Left_Glz0"
+            ]
+        },
+        {
+            "type": "FaceAbridged",
+            "name": "SecondFloor_Top",
+            "name_original": "Second Floor_Top",
+            "geometry": {
+                "type": "Face3D",
+                "boundary": [
+                    [
+                        10.0,
+                        0.0,
+                        6.0
+                    ],
+                    [
+                        10.0,
+                        10.0,
+                        6.0
+                    ],
+                    [
+                        0.0,
+                        10.0,
+                        6.0
+                    ],
+                    [
+                        0.0,
+                        0.0,
+                        6.0
+                    ]
+                ]
+            },
+            "properties": {
+                "type": "FaceProperties",
+                "energy": {
+                    "type": "FaceEnergyPropertiesAbridged"
+                }
+            },
+            "face_type": {
+                "type": "RoofCeiling"
+            },
+            "boundary_condition": {
+                "type": "Surface",
+                "sun_exposure": "NoSun",
+                "wind_exposure": "NoWind",
+                "view_factor": "autocalculate",
+                "bc_object": "AtticFace1"
+            },
+            "parent": "SecondFloor"
+        },
+        {
+            "type": "FaceAbridged",
+            "name": "AtticFace1",
+            "name_original": "Attic Face 1",
+            "geometry": {
+                "type": "Face3D",
+                "boundary": [
+                    [
+                        0.0,
+                        0.0,
+                        6.0
+                    ],
+                    [
+                        0.0,
+                        10.0,
+                        6.0
+                    ],
+                    [
+                        10.0,
+                        10.0,
+                        6.0
+                    ],
+                    [
+                        10.0,
+                        0.0,
+                        6.0
+                    ]
+                ]
+            },
+            "properties": {
+                "type": "FaceProperties",
+                "energy": {
+                    "type": "FaceEnergyPropertiesAbridged"
+                }
+            },
+            "face_type": {
+                "type": "Floor"
+            },
+            "boundary_condition": {
+                "type": "Surface",
+                "sun_exposure": "NoSun",
+                "wind_exposure": "NoWind",
+                "view_factor": "autocalculate",
+                "bc_object": "SecondFloor_Top"
+            },
+            "parent": "Attic"
+        },
+        {
+            "type": "FaceAbridged",
+            "name": "AtticFace2",
+            "name_original": "Attic Face 2",
+            "geometry": {
+                "type": "Face3D",
+                "boundary": [
+                    [
+                        0.0,
+                        0.0,
+                        6.0
+                    ],
+                    [
+                        5.0,
+                        0.0,
+                        9.0
+                    ],
+                    [
+                        5.0,
+                        10.0,
+                        9.0
+                    ],
+                    [
+                        0.0,
+                        10.0,
+                        6.0
+                    ]
+                ]
+            },
+            "properties": {
+                "type": "FaceProperties",
+                "energy": {
+                    "type": "FaceEnergyPropertiesAbridged"
+                }
+            },
+            "face_type": {
+                "type": "Wall"
+            },
+            "boundary_condition": {
+                "type": "Outdoors",
+                "sun_exposure": "SunExposed",
+                "wind_exposure": "WindExposed",
+                "view_factor": "autocalculate"
+            },
+            "parent": "Attic"
+        },
+        {
+            "type": "FaceAbridged",
+            "name": "AtticFace3",
+            "name_original": "Attic Face 3",
+            "geometry": {
+                "type": "Face3D",
+                "boundary": [
+                    [
+                        10.0,
+                        0.0,
+                        6.0
+                    ],
+                    [
+                        10.0,
+                        10.0,
+                        6.0
+                    ],
+                    [
+                        5.0,
+                        10.0,
+                        9.0
+                    ],
+                    [
+                        5.0,
+                        0.0,
+                        9.0
+                    ]
+                ]
+            },
+            "properties": {
+                "type": "FaceProperties",
+                "energy": {
+                    "type": "FaceEnergyPropertiesAbridged"
+                }
+            },
+            "face_type": {
+                "type": "Wall"
+            },
+            "boundary_condition": {
+                "type": "Outdoors",
+                "sun_exposure": "SunExposed",
+                "wind_exposure": "WindExposed",
+                "view_factor": "autocalculate"
+            },
+            "parent": "Attic"
+        },
+        {
+            "type": "FaceAbridged",
+            "name": "AtticFace4",
+            "name_original": "Attic Face 4",
+            "geometry": {
+                "type": "Face3D",
+                "boundary": [
+                    [
+                        0.0,
+                        0.0,
+                        6.0
+                    ],
+                    [
+                        10.0,
+                        0.0,
+                        6.0
+                    ],
+                    [
+                        5.0,
+                        0.0,
+                        9.0
+                    ]
+                ]
+            },
+            "properties": {
+                "type": "FaceProperties",
+                "energy": {
+                    "type": "FaceEnergyPropertiesAbridged"
+                }
+            },
+            "face_type": {
+                "type": "Wall"
+            },
+            "boundary_condition": {
+                "type": "Outdoors",
+                "sun_exposure": "SunExposed",
+                "wind_exposure": "WindExposed",
+                "view_factor": "autocalculate"
+            },
+            "parent": "Attic"
+        },
+        {
+            "type": "FaceAbridged",
+            "name": "AtticFace5",
+            "name_original": "Attic Face 5",
+            "geometry": {
+                "type": "Face3D",
+                "boundary": [
+                    [
+                        10.0,
+                        10.0,
+                        6.0
+                    ],
+                    [
+                        0.0,
+                        10.0,
+                        6.0
+                    ],
+                    [
+                        5.0,
+                        10.0,
+                        9.0
+                    ]
+                ]
+            },
+            "properties": {
+                "type": "FaceProperties",
+                "energy": {
+                    "type": "FaceEnergyPropertiesAbridged"
+                }
+            },
+            "face_type": {
+                "type": "Wall"
+            },
+            "boundary_condition": {
+                "type": "Outdoors",
+                "sun_exposure": "SunExposed",
+                "wind_exposure": "WindExposed",
+                "view_factor": "autocalculate"
+            },
+            "parent": "Attic"
+        }
+    ],
+    "shades": [],
+    "apertures": [
+        {
+            "type": "ApertureAbridged",
+            "name": "FirstFloor_Front_Glz0",
+            "name_original": "First Floor_Front_Glz0",
+            "geometry": {
+                "type": "Face3D",
+                "boundary": [
+                    [
+                        7.23606797749979,
+                        10.0,
+                        0.8291796067500631
+                    ],
+                    [
+                        2.76393202250021,
+                        10.0,
+                        0.8291796067500631
+                    ],
+                    [
+                        2.76393202250021,
+                        10.0,
+                        2.170820393249937
+                    ],
+                    [
+                        7.23606797749979,
+                        10.0,
+                        2.170820393249937
+                    ]
+                ]
+            },
+            "properties": {
+                "type": "ApertureProperties",
+                "energy": {
+                    "type": "ApertureEnergyPropertiesAbridged"
+                }
+            },
+            "aperture_type": {
+                "type": "Window"
+            },
+            "boundary_condition": {
+                "type": "Outdoors",
+                "sun_exposure": "SunExposed",
+                "wind_exposure": "WindExposed",
+                "view_factor": "autocalculate"
+            },
+            "parent": "FirstFloor_Front"
+        },
+        {
+            "type": "ApertureAbridged",
+            "name": "FirstFloor_Right_Glz0",
+            "name_original": "First Floor_Right_Glz0",
+            "geometry": {
+                "type": "Face3D",
+                "boundary": [
+                    [
+                        10.0,
+                        2.76393202250021,
+                        0.8291796067500631
+                    ],
+                    [
+                        10.0,
+                        7.23606797749979,
+                        0.8291796067500631
+                    ],
+                    [
+                        10.0,
+                        7.23606797749979,
+                        2.170820393249937
+                    ],
+                    [
+                        10.0,
+                        2.76393202250021,
+                        2.170820393249937
+                    ]
+                ]
+            },
+            "properties": {
+                "type": "ApertureProperties",
+                "energy": {
+                    "type": "ApertureEnergyPropertiesAbridged"
+                }
+            },
+            "aperture_type": {
+                "type": "Window"
+            },
+            "boundary_condition": {
+                "type": "Outdoors",
+                "sun_exposure": "SunExposed",
+                "wind_exposure": "WindExposed",
+                "view_factor": "autocalculate"
+            },
+            "parent": "FirstFloor_Right"
+        },
+        {
+            "type": "ApertureAbridged",
+            "name": "FirstFloor_Back_Glz0",
+            "name_original": "First Floor_Back_Glz0",
+            "geometry": {
+                "type": "Face3D",
+                "boundary": [
+                    [
+                        2.76393202250021,
+                        0.0,
+                        0.8291796067500631
+                    ],
+                    [
+                        7.23606797749979,
+                        0.0,
+                        0.8291796067500631
+                    ],
+                    [
+                        7.23606797749979,
+                        0.0,
+                        2.170820393249937
+                    ],
+                    [
+                        2.76393202250021,
+                        0.0,
+                        2.170820393249937
+                    ]
+                ]
+            },
+            "properties": {
+                "type": "ApertureProperties",
+                "energy": {
+                    "type": "ApertureEnergyPropertiesAbridged"
+                }
+            },
+            "aperture_type": {
+                "type": "Window"
+            },
+            "boundary_condition": {
+                "type": "Outdoors",
+                "sun_exposure": "SunExposed",
+                "wind_exposure": "WindExposed",
+                "view_factor": "autocalculate"
+            },
+            "parent": "FirstFloor_Back"
+        },
+        {
+            "type": "ApertureAbridged",
+            "name": "FirstFloor_Left_Glz0",
+            "name_original": "First Floor_Left_Glz0",
+            "geometry": {
+                "type": "Face3D",
+                "boundary": [
+                    [
+                        0.0,
+                        7.23606797749979,
+                        0.8291796067500631
+                    ],
+                    [
+                        0.0,
+                        2.76393202250021,
+                        0.8291796067500631
+                    ],
+                    [
+                        0.0,
+                        2.76393202250021,
+                        2.170820393249937
+                    ],
+                    [
+                        0.0,
+                        7.23606797749979,
+                        2.170820393249937
+                    ]
+                ]
+            },
+            "properties": {
+                "type": "ApertureProperties",
+                "energy": {
+                    "type": "ApertureEnergyPropertiesAbridged"
+                }
+            },
+            "aperture_type": {
+                "type": "Window"
+            },
+            "boundary_condition": {
+                "type": "Outdoors",
+                "sun_exposure": "SunExposed",
+                "wind_exposure": "WindExposed",
+                "view_factor": "autocalculate"
+            },
+            "parent": "FirstFloor_Left"
+        },
+        {
+            "type": "ApertureAbridged",
+            "name": "SecondFloor_Front_Glz0",
+            "name_original": "Second Floor_Front_Glz0",
+            "geometry": {
+                "type": "Face3D",
+                "boundary": [
+                    [
+                        7.23606797749979,
+                        10.0,
+                        3.829179606750063
+                    ],
+                    [
+                        2.76393202250021,
+                        10.0,
+                        3.829179606750063
+                    ],
+                    [
+                        2.76393202250021,
+                        10.0,
+                        5.170820393249937
+                    ],
+                    [
+                        7.23606797749979,
+                        10.0,
+                        5.170820393249937
+                    ]
+                ]
+            },
+            "properties": {
+                "type": "ApertureProperties",
+                "energy": {
+                    "type": "ApertureEnergyPropertiesAbridged"
+                }
+            },
+            "aperture_type": {
+                "type": "Window"
+            },
+            "boundary_condition": {
+                "type": "Outdoors",
+                "sun_exposure": "SunExposed",
+                "wind_exposure": "WindExposed",
+                "view_factor": "autocalculate"
+            },
+            "parent": "SecondFloor_Front"
+        },
+        {
+            "type": "ApertureAbridged",
+            "name": "SecondFloor_Right_Glz0",
+            "name_original": "Second Floor_Right_Glz0",
+            "geometry": {
+                "type": "Face3D",
+                "boundary": [
+                    [
+                        10.0,
+                        2.76393202250021,
+                        3.829179606750063
+                    ],
+                    [
+                        10.0,
+                        7.23606797749979,
+                        3.829179606750063
+                    ],
+                    [
+                        10.0,
+                        7.23606797749979,
+                        5.170820393249937
+                    ],
+                    [
+                        10.0,
+                        2.76393202250021,
+                        5.170820393249937
+                    ]
+                ]
+            },
+            "properties": {
+                "type": "ApertureProperties",
+                "energy": {
+                    "type": "ApertureEnergyPropertiesAbridged"
+                }
+            },
+            "aperture_type": {
+                "type": "Window"
+            },
+            "boundary_condition": {
+                "type": "Outdoors",
+                "sun_exposure": "SunExposed",
+                "wind_exposure": "WindExposed",
+                "view_factor": "autocalculate"
+            },
+            "parent": "SecondFloor_Right"
+        },
+        {
+            "type": "ApertureAbridged",
+            "name": "SecondFloor_Back_Glz0",
+            "name_original": "Second Floor_Back_Glz0",
+            "geometry": {
+                "type": "Face3D",
+                "boundary": [
+                    [
+                        2.76393202250021,
+                        0.0,
+                        3.829179606750063
+                    ],
+                    [
+                        7.23606797749979,
+                        0.0,
+                        3.829179606750063
+                    ],
+                    [
+                        7.23606797749979,
+                        0.0,
+                        5.170820393249937
+                    ],
+                    [
+                        2.76393202250021,
+                        0.0,
+                        5.170820393249937
+                    ]
+                ]
+            },
+            "properties": {
+                "type": "ApertureProperties",
+                "energy": {
+                    "type": "ApertureEnergyPropertiesAbridged"
+                }
+            },
+            "aperture_type": {
+                "type": "Window"
+            },
+            "boundary_condition": {
+                "type": "Outdoors",
+                "sun_exposure": "SunExposed",
+                "wind_exposure": "WindExposed",
+                "view_factor": "autocalculate"
+            },
+            "parent": "SecondFloor_Back"
+        },
+        {
+            "type": "ApertureAbridged",
+            "name": "SecondFloor_Left_Glz0",
+            "name_original": "Second Floor_Left_Glz0",
+            "geometry": {
+                "type": "Face3D",
+                "boundary": [
+                    [
+                        0.0,
+                        7.23606797749979,
+                        3.829179606750063
+                    ],
+                    [
+                        0.0,
+                        2.76393202250021,
+                        3.829179606750063
+                    ],
+                    [
+                        0.0,
+                        2.76393202250021,
+                        5.170820393249937
+                    ],
+                    [
+                        0.0,
+                        7.23606797749979,
+                        5.170820393249937
+                    ]
+                ]
+            },
+            "properties": {
+                "type": "ApertureProperties",
+                "energy": {
+                    "type": "ApertureEnergyPropertiesAbridged"
+                }
+            },
+            "aperture_type": {
+                "type": "Window"
+            },
+            "boundary_condition": {
+                "type": "Outdoors",
+                "sun_exposure": "SunExposed",
+                "wind_exposure": "WindExposed",
+                "view_factor": "autocalculate"
+            },
+            "parent": "SecondFloor_Left"
+        }
+    ],
+    "doors": []
+}

--- a/app/models/samples/json/model_shoe_box.json
+++ b/app/models/samples/json/model_shoe_box.json
@@ -1,0 +1,614 @@
+{
+    "type": "Model",
+    "name": "ShoeBox",
+    "name_original": "Shoe Box",
+    "properties": {
+        "type": "ModelProperties",
+        "energy": {
+            "type": "ModelEnergyProperties",
+            "construction_sets": [
+                {
+                    "type": "ConstructionSetAbridged",
+                    "name": "Shoe Box Construction Set",
+                    "wall_set": {
+                        "type": "WallSetAbridged",
+                        "exterior_construction": "Generic Exterior Brick Wall",
+                        "interior_construction": "Generic Interior Wall",
+                        "ground_construction": null
+                    },
+                    "floor_set": {
+                        "type": "FloorSetAbridged",
+                        "exterior_construction": null,
+                        "interior_construction": "Generic Interior Floor",
+                        "ground_construction": null
+                    },
+                    "roof_ceiling_set": {
+                        "type": "RoofCeilingSetAbridged",
+                        "exterior_construction": null,
+                        "interior_construction": "Generic Interior Ceiling",
+                        "ground_construction": null
+                    },
+                    "aperture_set": {
+                        "type": "ApertureSetAbridged",
+                        "fixed_window_construction": "Generic Double Pane Window",
+                        "interior_construction": null,
+                        "skylight_construction": null,
+                        "operable_window_construction": null,
+                        "glass_door_construction": null
+                    },
+                    "door_set": {
+                        "type": "DoorSetAbridged",
+                        "exterior_construction": null,
+                        "interior_construction": null,
+                        "overhead_construction": null
+                    }
+                }
+            ],
+            "constructions": [
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "name": "Generic Exterior Brick Wall",
+                    "layers": [
+                        "Generic Brick",
+                        "Generic Lightweight Concrete",
+                        "Generic 50mm Insulation Board",
+                        "Generic Wall Air Gap",
+                        "Generic Gypsum Board"
+                    ]
+                },
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "name": "Generic Interior Ceiling",
+                    "layers": [
+                        "Generic Lightweight Concrete",
+                        "Generic Ceiling Air Gap",
+                        "Generic Acoustic Tile"
+                    ]
+                },
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "name": "Generic Interior Floor",
+                    "layers": [
+                        "Generic Acoustic Tile",
+                        "Generic Ceiling Air Gap",
+                        "Generic Lightweight Concrete"
+                    ]
+                },
+                {
+                    "type": "WindowConstructionAbridged",
+                    "name": "Generic Double Pane Window",
+                    "layers": [
+                        "Generic Clear Glass",
+                        "Generic Window Air Gap",
+                        "Generic Clear Glass"
+                    ]
+                },
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "name": "Generic Interior Wall",
+                    "layers": [
+                        "Generic Gypsum Board",
+                        "Generic Wall Air Gap",
+                        "Generic Gypsum Board"
+                    ]
+                }
+            ],
+            "materials": [
+                {
+                    "type": "EnergyMaterial",
+                    "name": "Generic 50mm Insulation Board",
+                    "roughness": "MediumRough",
+                    "thickness": 0.05,
+                    "conductivity": 0.03,
+                    "density": 43.0,
+                    "specific_heat": 1210.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.7,
+                    "visible_absorptance": 0.7
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "name": "Generic Ceiling Air Gap",
+                    "roughness": "Smooth",
+                    "thickness": 0.1,
+                    "conductivity": 0.556,
+                    "density": 1.28,
+                    "specific_heat": 1000.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.7,
+                    "visible_absorptance": 0.7
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "name": "Generic Wall Air Gap",
+                    "roughness": "Smooth",
+                    "thickness": 0.1,
+                    "conductivity": 0.667,
+                    "density": 1.28,
+                    "specific_heat": 1000.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.7,
+                    "visible_absorptance": 0.7
+                },
+                {
+                    "type": "EnergyWindowMaterialGas",
+                    "name": "Generic Window Air Gap",
+                    "thickness": 0.0127,
+                    "gas_type": "Air"
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "name": "Generic Lightweight Concrete",
+                    "roughness": "MediumRough",
+                    "thickness": 0.1,
+                    "conductivity": 0.53,
+                    "density": 1280.0,
+                    "specific_heat": 840.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.8,
+                    "visible_absorptance": 0.8
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "name": "Generic Brick",
+                    "roughness": "MediumRough",
+                    "thickness": 0.1,
+                    "conductivity": 0.9,
+                    "density": 1920.0,
+                    "specific_heat": 790.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.7,
+                    "visible_absorptance": 0.7
+                },
+                {
+                    "type": "EnergyWindowMaterialGlazing",
+                    "name": "Generic Clear Glass",
+                    "thickness": 0.006,
+                    "solar_transmittance": 0.771,
+                    "solar_reflectance": 0.07,
+                    "solar_reflectance_back": 0.07,
+                    "visible_transmittance": 0.884,
+                    "visible_reflectance": 0.0804,
+                    "visible_reflectance_back": 0.0804,
+                    "infrared_transmittance": 0.0,
+                    "emissivity": 0.84,
+                    "emissivity_back": 0.84,
+                    "conductivity": 1.0,
+                    "dirt_correction": 1.0,
+                    "solar_diffusing": false
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "name": "Generic Gypsum Board",
+                    "roughness": "MediumSmooth",
+                    "thickness": 0.0127,
+                    "conductivity": 0.16,
+                    "density": 800.0,
+                    "specific_heat": 1090.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.5,
+                    "visible_absorptance": 0.5
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "name": "Generic Acoustic Tile",
+                    "roughness": "MediumSmooth",
+                    "thickness": 0.02,
+                    "conductivity": 0.06,
+                    "density": 368.0,
+                    "specific_heat": 590.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.3,
+                    "visible_absorptance": 0.3
+                }
+            ]
+        }
+    },
+    "rooms": [
+        {
+            "type": "RoomAbridged",
+            "name": "SimpleShoeBoxZone",
+            "name_original": "Simple Shoe Box Zone",
+            "properties": {
+                "type": "RoomProperties",
+                "energy": {
+                    "type": "RoomEnergyPropertiesAbridged",
+                    "program_type": null,
+                    "construction_set": "Shoe Box Construction Set",
+                    "people": null,
+                    "lighting": null,
+                    "electric_equipment": null,
+                    "gas_equipment": null,
+                    "infiltration": null,
+                    "ventilation": null
+                }
+            },
+            "faces": [
+                "SimpleShoeBoxZone_Bottom",
+                "SimpleShoeBoxZone_Front",
+                "SimpleShoeBoxZone_Right",
+                "SimpleShoeBoxZone_Back",
+                "SimpleShoeBoxZone_Left",
+                "SimpleShoeBoxZone_Top"
+            ]
+        }
+    ],
+    "faces": [
+        {
+            "type": "FaceAbridged",
+            "name": "SimpleShoeBoxZone_Bottom",
+            "name_original": "Simple Shoe Box Zone_Bottom",
+            "geometry": {
+                "type": "Face3D",
+                "boundary": [
+                    [
+                        0.0,
+                        0.0,
+                        0.0
+                    ],
+                    [
+                        0.0,
+                        10.0,
+                        0.0
+                    ],
+                    [
+                        5.0,
+                        10.0,
+                        0.0
+                    ],
+                    [
+                        5.0,
+                        0.0,
+                        0.0
+                    ]
+                ]
+            },
+            "properties": {
+                "type": "FaceProperties",
+                "energy": {
+                    "type": "FaceEnergyPropertiesAbridged"
+                }
+            },
+            "face_type": {
+                "type": "Floor"
+            },
+            "boundary_condition": {
+                "type": "Adiabatic",
+                "sun_exposure": "NoSun",
+                "wind_exposure": "NoWind",
+                "view_factor": "autocalculate"
+            },
+            "parent": "SimpleShoeBoxZone"
+        },
+        {
+            "type": "FaceAbridged",
+            "name": "SimpleShoeBoxZone_Front",
+            "name_original": "Simple Shoe Box Zone_Front",
+            "geometry": {
+                "type": "Face3D",
+                "boundary": [
+                    [
+                        5.0,
+                        10.0,
+                        0.0
+                    ],
+                    [
+                        0.0,
+                        10.0,
+                        0.0
+                    ],
+                    [
+                        0.0,
+                        10.0,
+                        3.0
+                    ],
+                    [
+                        5.0,
+                        10.0,
+                        3.0
+                    ]
+                ]
+            },
+            "properties": {
+                "type": "FaceProperties",
+                "energy": {
+                    "type": "FaceEnergyPropertiesAbridged"
+                }
+            },
+            "face_type": {
+                "type": "Wall"
+            },
+            "boundary_condition": {
+                "type": "Outdoors",
+                "sun_exposure": "SunExposed",
+                "wind_exposure": "WindExposed",
+                "view_factor": "autocalculate"
+            },
+            "parent": "SimpleShoeBoxZone",
+            "apertures": [
+                "SimpleShoeBoxZone_Front_Glz0",
+                "SimpleShoeBoxZone_Front_Glz1"
+            ]
+        },
+        {
+            "type": "FaceAbridged",
+            "name": "SimpleShoeBoxZone_Right",
+            "name_original": "Simple Shoe Box Zone_Right",
+            "geometry": {
+                "type": "Face3D",
+                "boundary": [
+                    [
+                        5.0,
+                        10.0,
+                        3.0
+                    ],
+                    [
+                        5.0,
+                        0.0,
+                        3.0
+                    ],
+                    [
+                        5.0,
+                        0.0,
+                        0.0
+                    ],
+                    [
+                        5.0,
+                        10.0,
+                        0.0
+                    ]
+                ]
+            },
+            "properties": {
+                "type": "FaceProperties",
+                "energy": {
+                    "type": "FaceEnergyPropertiesAbridged"
+                }
+            },
+            "face_type": {
+                "type": "Wall"
+            },
+            "boundary_condition": {
+                "type": "Adiabatic",
+                "sun_exposure": "NoSun",
+                "wind_exposure": "NoWind",
+                "view_factor": "autocalculate"
+            },
+            "parent": "SimpleShoeBoxZone"
+        },
+        {
+            "type": "FaceAbridged",
+            "name": "SimpleShoeBoxZone_Back",
+            "name_original": "Simple Shoe Box Zone_Back",
+            "geometry": {
+                "type": "Face3D",
+                "boundary": [
+                    [
+                        0.0,
+                        0.0,
+                        0.0
+                    ],
+                    [
+                        5.0,
+                        0.0,
+                        0.0
+                    ],
+                    [
+                        5.0,
+                        0.0,
+                        3.0
+                    ],
+                    [
+                        0.0,
+                        0.0,
+                        3.0
+                    ]
+                ]
+            },
+            "properties": {
+                "type": "FaceProperties",
+                "energy": {
+                    "type": "FaceEnergyPropertiesAbridged"
+                }
+            },
+            "face_type": {
+                "type": "Wall"
+            },
+            "boundary_condition": {
+                "type": "Adiabatic",
+                "sun_exposure": "NoSun",
+                "wind_exposure": "NoWind",
+                "view_factor": "autocalculate"
+            },
+            "parent": "SimpleShoeBoxZone"
+        },
+        {
+            "type": "FaceAbridged",
+            "name": "SimpleShoeBoxZone_Left",
+            "name_original": "Simple Shoe Box Zone_Left",
+            "geometry": {
+                "type": "Face3D",
+                "boundary": [
+                    [
+                        0.0,
+                        0.0,
+                        0.0
+                    ],
+                    [
+                        0.0,
+                        0.0,
+                        3.0
+                    ],
+                    [
+                        0.0,
+                        10.0,
+                        3.0
+                    ],
+                    [
+                        0.0,
+                        10.0,
+                        0.0
+                    ]
+                ]
+            },
+            "properties": {
+                "type": "FaceProperties",
+                "energy": {
+                    "type": "FaceEnergyPropertiesAbridged"
+                }
+            },
+            "face_type": {
+                "type": "Wall"
+            },
+            "boundary_condition": {
+                "type": "Adiabatic",
+                "sun_exposure": "NoSun",
+                "wind_exposure": "NoWind",
+                "view_factor": "autocalculate"
+            },
+            "parent": "SimpleShoeBoxZone"
+        },
+        {
+            "type": "FaceAbridged",
+            "name": "SimpleShoeBoxZone_Top",
+            "name_original": "Simple Shoe Box Zone_Top",
+            "geometry": {
+                "type": "Face3D",
+                "boundary": [
+                    [
+                        5.0,
+                        0.0,
+                        3.0
+                    ],
+                    [
+                        5.0,
+                        10.0,
+                        3.0
+                    ],
+                    [
+                        0.0,
+                        10.0,
+                        3.0
+                    ],
+                    [
+                        0.0,
+                        0.0,
+                        3.0
+                    ]
+                ]
+            },
+            "properties": {
+                "type": "FaceProperties",
+                "energy": {
+                    "type": "FaceEnergyPropertiesAbridged"
+                }
+            },
+            "face_type": {
+                "type": "RoofCeiling"
+            },
+            "boundary_condition": {
+                "type": "Adiabatic",
+                "sun_exposure": "NoSun",
+                "wind_exposure": "NoWind",
+                "view_factor": "autocalculate"
+            },
+            "parent": "SimpleShoeBoxZone"
+        }
+    ],
+    "shades": [],
+    "apertures": [
+        {
+            "type": "ApertureAbridged",
+            "name": "SimpleShoeBoxZone_Front_Glz0",
+            "name_original": "Simple Shoe Box Zone_Front_Glz0",
+            "geometry": {
+                "type": "Face3D",
+                "boundary": [
+                    [
+                        4.5,
+                        10.0,
+                        0.7
+                    ],
+                    [
+                        3.0,
+                        10.0,
+                        0.7
+                    ],
+                    [
+                        3.0,
+                        10.0,
+                        2.7
+                    ],
+                    [
+                        4.5,
+                        10.0,
+                        2.7
+                    ]
+                ]
+            },
+            "properties": {
+                "type": "ApertureProperties",
+                "energy": {
+                    "type": "ApertureEnergyPropertiesAbridged"
+                }
+            },
+            "aperture_type": {
+                "type": "Window"
+            },
+            "boundary_condition": {
+                "type": "Outdoors",
+                "sun_exposure": "SunExposed",
+                "wind_exposure": "WindExposed",
+                "view_factor": "autocalculate"
+            },
+            "parent": "SimpleShoeBoxZone_Front"
+        },
+        {
+            "type": "ApertureAbridged",
+            "name": "SimpleShoeBoxZone_Front_Glz1",
+            "name_original": "Simple Shoe Box Zone_Front_Glz1",
+            "geometry": {
+                "type": "Face3D",
+                "boundary": [
+                    [
+                        2.0,
+                        10.0,
+                        0.7
+                    ],
+                    [
+                        0.5,
+                        10.0,
+                        0.7
+                    ],
+                    [
+                        0.5,
+                        10.0,
+                        2.7
+                    ],
+                    [
+                        2.0,
+                        10.0,
+                        2.7
+                    ]
+                ]
+            },
+            "properties": {
+                "type": "ApertureProperties",
+                "energy": {
+                    "type": "ApertureEnergyPropertiesAbridged"
+                }
+            },
+            "aperture_type": {
+                "type": "Window"
+            },
+            "boundary_condition": {
+                "type": "Outdoors",
+                "sun_exposure": "SunExposed",
+                "wind_exposure": "WindExposed",
+                "view_factor": "autocalculate"
+            },
+            "parent": "SimpleShoeBoxZone_Front"
+        }
+    ],
+    "doors": []
+}

--- a/app/models/samples/json/model_single_zone_tiny_house.json
+++ b/app/models/samples/json/model_single_zone_tiny_house.json
@@ -1,0 +1,961 @@
+{
+    "type": "Model",
+    "name": "TinyHouse",
+    "name_original": "Tiny House",
+    "properties": {
+        "type": "ModelProperties",
+        "energy": {
+            "type": "ModelEnergyProperties",
+            "global_construction_set": {
+                "type": "ConstructionSetAbridged",
+                "name": "Default Generic Construction Set",
+                "wall_set": {
+                    "type": "WallSetAbridged",
+                    "exterior_construction": "Generic Exterior Brick Wall",
+                    "interior_construction": "Generic Interior Wall",
+                    "ground_construction": "Generic Underground Wall"
+                },
+                "floor_set": {
+                    "type": "FloorSetAbridged",
+                    "exterior_construction": "Generic Exposed Floor Slab",
+                    "interior_construction": "Generic Interior Floor",
+                    "ground_construction": "Generic Ground Slab"
+                },
+                "roof_ceiling_set": {
+                    "type": "RoofCeilingSetAbridged",
+                    "exterior_construction": "Generic Roof",
+                    "interior_construction": "Generic Interior Ceiling",
+                    "ground_construction": "Generic Underground Roof"
+                },
+                "aperture_set": {
+                    "type": "ApertureSetAbridged",
+                    "fixed_window_construction": "Generic Double Pane Window",
+                    "interior_construction": "Generic Single Pane Window",
+                    "skylight_construction": "Generic Double Pane Window",
+                    "operable_window_construction": "Generic Double Pane Window",
+                    "glass_door_construction": "Generic Double Pane Window"
+                },
+                "door_set": {
+                    "type": "DoorSetAbridged",
+                    "exterior_construction": "Generic Exterior Door",
+                    "interior_construction": "Generic Interior Door",
+                    "overhead_construction": "Generic Exterior Door"
+                }
+            },
+            "construction_sets": [],
+            "constructions": [
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "name": "Generic Interior Door",
+                    "layers": [
+                        "Generic 25mm Wood"
+                    ]
+                },
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "name": "Generic Roof",
+                    "layers": [
+                        "Generic Roof Membrane",
+                        "Generic 50mm Insulation Board",
+                        "Generic Lightweight Concrete",
+                        "Generic Ceiling Air Gap",
+                        "Generic Acoustic Tile"
+                    ]
+                },
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "name": "Generic Exterior Brick Wall",
+                    "layers": [
+                        "Generic Brick",
+                        "Generic Lightweight Concrete",
+                        "Generic 50mm Insulation Board",
+                        "Generic Wall Air Gap",
+                        "Generic Gypsum Board"
+                    ]
+                },
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "name": "Thermal Mass Floor",
+                    "layers": [
+                        "Thick Stone"
+                    ]
+                },
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "name": "Generic Underground Roof",
+                    "layers": [
+                        "Generic 50mm Insulation Board",
+                        "Generic Heavyweight Concrete",
+                        "Generic Ceiling Air Gap",
+                        "Generic Acoustic Tile"
+                    ]
+                },
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "name": "Generic Ground Slab",
+                    "layers": [
+                        "Generic 50mm Insulation Board",
+                        "Generic Heavyweight Concrete"
+                    ]
+                },
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "name": "Generic Interior Ceiling",
+                    "layers": [
+                        "Generic Lightweight Concrete",
+                        "Generic Ceiling Air Gap",
+                        "Generic Acoustic Tile"
+                    ]
+                },
+                {
+                    "type": "WindowConstructionAbridged",
+                    "name": "Generic Single Pane Window",
+                    "layers": [
+                        "Generic Clear Glass"
+                    ]
+                },
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "name": "Generic Exposed Floor Slab",
+                    "layers": [
+                        "Generic Metal Surface",
+                        "Generic Ceiling Air Gap",
+                        "Generic 50mm Insulation Board",
+                        "Generic Lightweight Concrete"
+                    ]
+                },
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "name": "Generic Underground Wall",
+                    "layers": [
+                        "Generic 50mm Insulation Board",
+                        "Generic Heavyweight Concrete"
+                    ]
+                },
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "name": "Generic Interior Floor",
+                    "layers": [
+                        "Generic Acoustic Tile",
+                        "Generic Ceiling Air Gap",
+                        "Generic Lightweight Concrete"
+                    ]
+                },
+                {
+                    "type": "WindowConstructionAbridged",
+                    "name": "Generic Double Pane Window",
+                    "layers": [
+                        "Generic Clear Glass",
+                        "Generic Window Air Gap",
+                        "Generic Clear Glass"
+                    ]
+                },
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "name": "Generic Interior Wall",
+                    "layers": [
+                        "Generic Gypsum Board",
+                        "Generic Wall Air Gap",
+                        "Generic Gypsum Board"
+                    ]
+                },
+                {
+                    "type": "OpaqueConstructionAbridged",
+                    "name": "Generic Exterior Door",
+                    "layers": [
+                        "Generic Metal Surface",
+                        "Generic 25mm Insulation Board",
+                        "Generic Metal Surface"
+                    ]
+                },
+                {
+                    "type": "WindowConstructionAbridged",
+                    "name": "Triple Pane Window",
+                    "layers": [
+                        "Generic Clear Glass",
+                        "Generic Window Air Gap",
+                        "Generic Clear Glass",
+                        "Generic Window Air Gap",
+                        "Generic Clear Glass"
+                    ]
+                }
+            ],
+            "materials": [
+                {
+                    "type": "EnergyMaterial",
+                    "name": "Generic 50mm Insulation Board",
+                    "roughness": "MediumRough",
+                    "thickness": 0.05,
+                    "conductivity": 0.03,
+                    "density": 43.0,
+                    "specific_heat": 1210.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.7,
+                    "visible_absorptance": 0.7
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "name": "Generic 25mm Wood",
+                    "roughness": "MediumSmooth",
+                    "thickness": 0.0254,
+                    "conductivity": 0.15,
+                    "density": 608.0,
+                    "specific_heat": 1630.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.5,
+                    "visible_absorptance": 0.5
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "name": "Generic Ceiling Air Gap",
+                    "roughness": "Smooth",
+                    "thickness": 0.1,
+                    "conductivity": 0.556,
+                    "density": 1.28,
+                    "specific_heat": 1000.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.7,
+                    "visible_absorptance": 0.7
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "name": "Generic Roof Membrane",
+                    "roughness": "MediumRough",
+                    "thickness": 0.01,
+                    "conductivity": 0.16,
+                    "density": 1120.0,
+                    "specific_heat": 1460.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.7,
+                    "visible_absorptance": 0.7
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "name": "Generic Wall Air Gap",
+                    "roughness": "Smooth",
+                    "thickness": 0.1,
+                    "conductivity": 0.667,
+                    "density": 1.28,
+                    "specific_heat": 1000.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.7,
+                    "visible_absorptance": 0.7
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "name": "Generic Heavyweight Concrete",
+                    "roughness": "MediumRough",
+                    "thickness": 0.2,
+                    "conductivity": 1.95,
+                    "density": 2240.0,
+                    "specific_heat": 900.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.8,
+                    "visible_absorptance": 0.8
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "name": "Generic 25mm Insulation Board",
+                    "roughness": "MediumRough",
+                    "thickness": 0.05,
+                    "conductivity": 0.03,
+                    "density": 43.0,
+                    "specific_heat": 1210.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.7,
+                    "visible_absorptance": 0.7
+                },
+                {
+                    "type": "EnergyWindowMaterialGas",
+                    "name": "Generic Window Air Gap",
+                    "thickness": 0.0127,
+                    "gas_type": "Air"
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "name": "Generic Lightweight Concrete",
+                    "roughness": "MediumRough",
+                    "thickness": 0.1,
+                    "conductivity": 0.53,
+                    "density": 1280.0,
+                    "specific_heat": 840.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.8,
+                    "visible_absorptance": 0.8
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "name": "Generic Brick",
+                    "roughness": "MediumRough",
+                    "thickness": 0.1,
+                    "conductivity": 0.9,
+                    "density": 1920.0,
+                    "specific_heat": 790.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.7,
+                    "visible_absorptance": 0.7
+                },
+                {
+                    "type": "EnergyWindowMaterialGlazing",
+                    "name": "Generic Clear Glass",
+                    "thickness": 0.006,
+                    "solar_transmittance": 0.771,
+                    "solar_reflectance": 0.07,
+                    "solar_reflectance_back": 0.07,
+                    "visible_transmittance": 0.884,
+                    "visible_reflectance": 0.0804,
+                    "visible_reflectance_back": 0.0804,
+                    "infrared_transmittance": 0.0,
+                    "emissivity": 0.84,
+                    "emissivity_back": 0.84,
+                    "conductivity": 1.0,
+                    "dirt_correction": 1.0,
+                    "solar_diffusing": false
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "name": "Generic Gypsum Board",
+                    "roughness": "MediumSmooth",
+                    "thickness": 0.0127,
+                    "conductivity": 0.16,
+                    "density": 800.0,
+                    "specific_heat": 1090.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.5,
+                    "visible_absorptance": 0.5
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "name": "Generic Acoustic Tile",
+                    "roughness": "MediumSmooth",
+                    "thickness": 0.02,
+                    "conductivity": 0.06,
+                    "density": 368.0,
+                    "specific_heat": 590.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.3,
+                    "visible_absorptance": 0.3
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "name": "Generic Metal Surface",
+                    "roughness": "Smooth",
+                    "thickness": 0.0015,
+                    "conductivity": 45.0,
+                    "density": 7690.0,
+                    "specific_heat": 410.0,
+                    "thermal_absorptance": 0.9,
+                    "solar_absorptance": 0.5,
+                    "visible_absorptance": 0.5
+                },
+                {
+                    "type": "EnergyMaterial",
+                    "name": "Thick Stone",
+                    "roughness": "Rough",
+                    "thickness": 0.3,
+                    "conductivity": 2.31,
+                    "density": 2322.0,
+                    "specific_heat": 832.0,
+                    "thermal_absorptance": 0.95,
+                    "solar_absorptance": 0.75,
+                    "visible_absorptance": 0.8
+                }
+            ]
+        }
+    },
+    "rooms": [
+        {
+            "type": "RoomAbridged",
+            "name": "TinyHouseZone",
+            "name_original": "Tiny House Zone",
+            "properties": {
+                "type": "RoomProperties",
+                "energy": {
+                    "type": "RoomEnergyPropertiesAbridged",
+                    "program_type": null,
+                    "construction_set": null,
+                    "people": null,
+                    "lighting": null,
+                    "electric_equipment": null,
+                    "gas_equipment": null,
+                    "infiltration": null,
+                    "ventilation": null
+                }
+            },
+            "faces": [
+                "TinyHouseZone_Bottom",
+                "TinyHouseZone_Front",
+                "TinyHouseZone_Right",
+                "TinyHouseZone_Back",
+                "TinyHouseZone_Left",
+                "TinyHouseZone_Top"
+            ],
+            "indoor_shades": [
+                "TinyHouseZone_Back_InShd0"
+            ],
+            "outdoor_shades": [
+                "TinyHouseZone_Back_OutShd0"
+            ]
+        }
+    ],
+    "faces": [
+        {
+            "type": "FaceAbridged",
+            "name": "TinyHouseZone_Bottom",
+            "name_original": "Tiny House Zone_Bottom",
+            "geometry": {
+                "type": "Face3D",
+                "boundary": [
+                    [
+                        0.0,
+                        0.0,
+                        0.0
+                    ],
+                    [
+                        0.0,
+                        10.0,
+                        0.0
+                    ],
+                    [
+                        5.0,
+                        10.0,
+                        0.0
+                    ],
+                    [
+                        5.0,
+                        0.0,
+                        0.0
+                    ]
+                ]
+            },
+            "properties": {
+                "type": "FaceProperties",
+                "energy": {
+                    "type": "FaceEnergyPropertiesAbridged",
+                    "construction": "Thermal Mass Floor"
+                }
+            },
+            "face_type": {
+                "type": "Floor"
+            },
+            "boundary_condition": {
+                "type": "Ground",
+                "sun_exposure": "NoSun",
+                "wind_exposure": "NoWind",
+                "view_factor": "autocalculate"
+            },
+            "parent": "TinyHouseZone"
+        },
+        {
+            "type": "FaceAbridged",
+            "name": "TinyHouseZone_Front",
+            "name_original": "Tiny House Zone_Front",
+            "geometry": {
+                "type": "Face3D",
+                "boundary": [
+                    [
+                        5.0,
+                        10.0,
+                        0.0
+                    ],
+                    [
+                        0.0,
+                        10.0,
+                        0.0
+                    ],
+                    [
+                        0.0,
+                        10.0,
+                        3.0
+                    ],
+                    [
+                        5.0,
+                        10.0,
+                        3.0
+                    ]
+                ]
+            },
+            "properties": {
+                "type": "FaceProperties",
+                "energy": {
+                    "type": "FaceEnergyPropertiesAbridged"
+                }
+            },
+            "face_type": {
+                "type": "Wall"
+            },
+            "boundary_condition": {
+                "type": "Outdoors",
+                "sun_exposure": "SunExposed",
+                "wind_exposure": "WindExposed",
+                "view_factor": "autocalculate"
+            },
+            "parent": "TinyHouseZone",
+            "apertures": [
+                "FrontAperture"
+            ],
+            "doors": [
+                "FrontDoor"
+            ]
+        },
+        {
+            "type": "FaceAbridged",
+            "name": "TinyHouseZone_Right",
+            "name_original": "Tiny House Zone_Right",
+            "geometry": {
+                "type": "Face3D",
+                "boundary": [
+                    [
+                        5.0,
+                        10.0,
+                        3.0
+                    ],
+                    [
+                        5.0,
+                        0.0,
+                        3.0
+                    ],
+                    [
+                        5.0,
+                        0.0,
+                        0.0
+                    ],
+                    [
+                        5.0,
+                        10.0,
+                        0.0
+                    ]
+                ]
+            },
+            "properties": {
+                "type": "FaceProperties",
+                "energy": {
+                    "type": "FaceEnergyPropertiesAbridged"
+                }
+            },
+            "face_type": {
+                "type": "Wall"
+            },
+            "boundary_condition": {
+                "type": "Outdoors",
+                "sun_exposure": "SunExposed",
+                "wind_exposure": "WindExposed",
+                "view_factor": "autocalculate"
+            },
+            "parent": "TinyHouseZone"
+        },
+        {
+            "type": "FaceAbridged",
+            "name": "TinyHouseZone_Back",
+            "name_original": "Tiny House Zone_Back",
+            "geometry": {
+                "type": "Face3D",
+                "boundary": [
+                    [
+                        0.0,
+                        0.0,
+                        0.0
+                    ],
+                    [
+                        5.0,
+                        0.0,
+                        0.0
+                    ],
+                    [
+                        5.0,
+                        0.0,
+                        3.0
+                    ],
+                    [
+                        0.0,
+                        0.0,
+                        3.0
+                    ]
+                ]
+            },
+            "properties": {
+                "type": "FaceProperties",
+                "energy": {
+                    "type": "FaceEnergyPropertiesAbridged"
+                }
+            },
+            "face_type": {
+                "type": "Wall"
+            },
+            "boundary_condition": {
+                "type": "Outdoors",
+                "sun_exposure": "SunExposed",
+                "wind_exposure": "WindExposed",
+                "view_factor": "autocalculate"
+            },
+            "parent": "TinyHouseZone",
+            "apertures": [
+                "TinyHouseZone_Back_Glz0"
+            ]
+        },
+        {
+            "type": "FaceAbridged",
+            "name": "TinyHouseZone_Left",
+            "name_original": "Tiny House Zone_Left",
+            "geometry": {
+                "type": "Face3D",
+                "boundary": [
+                    [
+                        0.0,
+                        0.0,
+                        0.0
+                    ],
+                    [
+                        0.0,
+                        0.0,
+                        3.0
+                    ],
+                    [
+                        0.0,
+                        10.0,
+                        3.0
+                    ],
+                    [
+                        0.0,
+                        10.0,
+                        0.0
+                    ]
+                ]
+            },
+            "properties": {
+                "type": "FaceProperties",
+                "energy": {
+                    "type": "FaceEnergyPropertiesAbridged"
+                }
+            },
+            "face_type": {
+                "type": "Wall"
+            },
+            "boundary_condition": {
+                "type": "Outdoors",
+                "sun_exposure": "SunExposed",
+                "wind_exposure": "WindExposed",
+                "view_factor": "autocalculate"
+            },
+            "parent": "TinyHouseZone"
+        },
+        {
+            "type": "FaceAbridged",
+            "name": "TinyHouseZone_Top",
+            "name_original": "Tiny House Zone_Top",
+            "geometry": {
+                "type": "Face3D",
+                "boundary": [
+                    [
+                        5.0,
+                        0.0,
+                        3.0
+                    ],
+                    [
+                        5.0,
+                        10.0,
+                        3.0
+                    ],
+                    [
+                        0.0,
+                        10.0,
+                        3.0
+                    ],
+                    [
+                        0.0,
+                        0.0,
+                        3.0
+                    ]
+                ]
+            },
+            "properties": {
+                "type": "FaceProperties",
+                "energy": {
+                    "type": "FaceEnergyPropertiesAbridged"
+                }
+            },
+            "face_type": {
+                "type": "RoofCeiling"
+            },
+            "boundary_condition": {
+                "type": "Outdoors",
+                "sun_exposure": "SunExposed",
+                "wind_exposure": "WindExposed",
+                "view_factor": "autocalculate"
+            },
+            "parent": "TinyHouseZone"
+        }
+    ],
+    "shades": [
+        {
+            "type": "ShadeAbridged",
+            "name": "TinyHouseZone_Back_InShd0",
+            "name_original": "Tiny House Zone_Back_InShd0",
+            "geometry": {
+                "type": "Face3D",
+                "boundary": [
+                    [
+                        5.0,
+                        0.0,
+                        2.9999999
+                    ],
+                    [
+                        0.0,
+                        0.0,
+                        2.9999999
+                    ],
+                    [
+                        0.0,
+                        0.5,
+                        2.9999999
+                    ],
+                    [
+                        5.0,
+                        0.5,
+                        2.9999999
+                    ]
+                ]
+            },
+            "properties": {
+                "type": "ShadeProperties",
+                "energy": {
+                    "type": "ShadeEnergyPropertiesAbridged",
+                    "diffuse_reflectance": 0.2,
+                    "specular_reflectance": 0.0,
+                    "transmittance": 0.0
+                }
+            },
+            "parent": "TinyHouseZone"
+        },
+        {
+            "type": "ShadeAbridged",
+            "name": "TinyHouseZone_Back_OutShd0",
+            "name_original": "Tiny House Zone_Back_OutShd0",
+            "geometry": {
+                "type": "Face3D",
+                "boundary": [
+                    [
+                        5.0,
+                        0.0,
+                        2.9999999
+                    ],
+                    [
+                        0.0,
+                        0.0,
+                        2.9999999
+                    ],
+                    [
+                        0.0,
+                        -0.5,
+                        2.9999999
+                    ],
+                    [
+                        5.0,
+                        -0.5,
+                        2.9999999
+                    ]
+                ]
+            },
+            "properties": {
+                "type": "ShadeProperties",
+                "energy": {
+                    "type": "ShadeEnergyPropertiesAbridged",
+                    "diffuse_reflectance": 0.2,
+                    "specular_reflectance": 0.0,
+                    "transmittance": 0.0
+                }
+            },
+            "parent": "TinyHouseZone"
+        },
+        {
+            "type": "ShadeAbridged",
+            "name": "TreeCanopy",
+            "name_original": "Tree Canopy",
+            "geometry": {
+                "type": "Face3D",
+                "boundary": [
+                    [
+                        3.2679491924311224,
+                        -4.0,
+                        4.0
+                    ],
+                    [
+                        5.0,
+                        -5.0,
+                        4.0
+                    ],
+                    [
+                        6.732050807568877,
+                        -4.000000000000001,
+                        4.0
+                    ],
+                    [
+                        6.732050807568878,
+                        -2.000000000000001,
+                        4.0
+                    ],
+                    [
+                        5.000000000000002,
+                        -1.0,
+                        4.0
+                    ],
+                    [
+                        3.2679491924311233,
+                        -1.9999999999999987,
+                        4.0
+                    ]
+                ]
+            },
+            "properties": {
+                "type": "ShadeProperties",
+                "energy": {
+                    "type": "ShadeEnergyPropertiesAbridged",
+                    "diffuse_reflectance": 0.2,
+                    "specular_reflectance": 0.0,
+                    "transmittance": 0.75
+                }
+            }
+        }
+    ],
+    "apertures": [
+        {
+            "type": "ApertureAbridged",
+            "name": "FrontAperture",
+            "name_original": "Front Aperture",
+            "geometry": {
+                "type": "Face3D",
+                "boundary": [
+                    [
+                        4.5,
+                        10.0,
+                        1.0
+                    ],
+                    [
+                        2.5,
+                        10.0,
+                        1.0
+                    ],
+                    [
+                        2.5,
+                        10.0,
+                        2.5
+                    ],
+                    [
+                        4.5,
+                        10.0,
+                        2.5
+                    ]
+                ]
+            },
+            "properties": {
+                "type": "ApertureProperties",
+                "energy": {
+                    "type": "ApertureEnergyPropertiesAbridged",
+                    "construction": "Triple Pane Window"
+                }
+            },
+            "aperture_type": {
+                "type": "Window"
+            },
+            "boundary_condition": {
+                "type": "Outdoors",
+                "sun_exposure": "SunExposed",
+                "wind_exposure": "WindExposed",
+                "view_factor": "autocalculate"
+            },
+            "parent": "TinyHouseZone_Front"
+        },
+        {
+            "type": "ApertureAbridged",
+            "name": "TinyHouseZone_Back_Glz0",
+            "name_original": "Tiny House Zone_Back_Glz0",
+            "geometry": {
+                "type": "Face3D",
+                "boundary": [
+                    [
+                        0.9188611699158102,
+                        0.0,
+                        0.5513167019494862
+                    ],
+                    [
+                        4.08113883008419,
+                        0.0,
+                        0.5513167019494862
+                    ],
+                    [
+                        4.08113883008419,
+                        0.0,
+                        2.448683298050514
+                    ],
+                    [
+                        0.9188611699158102,
+                        0.0,
+                        2.448683298050514
+                    ]
+                ]
+            },
+            "properties": {
+                "type": "ApertureProperties",
+                "energy": {
+                    "type": "ApertureEnergyPropertiesAbridged"
+                }
+            },
+            "aperture_type": {
+                "type": "Window"
+            },
+            "boundary_condition": {
+                "type": "Outdoors",
+                "sun_exposure": "SunExposed",
+                "wind_exposure": "WindExposed",
+                "view_factor": "autocalculate"
+            },
+            "parent": "TinyHouseZone_Back"
+        }
+    ],
+    "doors": [
+        {
+            "type": "DoorAbridged",
+            "name": "FrontDoor",
+            "name_original": "Front Door",
+            "geometry": {
+                "type": "Face3D",
+                "boundary": [
+                    [
+                        2.0,
+                        10.0,
+                        0.1
+                    ],
+                    [
+                        1.0,
+                        10.0,
+                        0.1
+                    ],
+                    [
+                        1.0,
+                        10.0,
+                        2.5
+                    ],
+                    [
+                        2.0,
+                        10.0,
+                        2.5
+                    ]
+                ]
+            },
+            "properties": {
+                "type": "DoorProperties",
+                "energy": {
+                    "type": "DoorEnergyPropertiesAbridged"
+                }
+            },
+            "boundary_condition": {
+                "type": "Outdoors",
+                "sun_exposure": "SunExposed",
+                "wind_exposure": "WindExposed",
+                "view_factor": "autocalculate"
+            },
+            "parent": "TinyHouseZone_Front"
+        }
+    ],
+    "north_angle": 15.0
+}


### PR DESCRIPTION
@tanushree04 , @macumber , and @mostaphaRoudsari ,

This PR includes 3 samples of the Model schema (2 for single zone energy models and one that is multizone) so that @tanushree04 has a good reference point for the work that will be done over at least the next 3 weeks.

As you can infer, the minimum amount of Python code for generating the model schema files is done and so I can generate a wide variety of cases with ease.  The one thing that is missing right now from the examples and the Python code is that there are no Loads, Schedules, or ProgramTypes.  However, the first sample (1_single_zone_tiny_house.json) includes all of the 5 geometry objects.  Also, the samples use all of the construction-related schemas we developed over the last few months (ConstructionSetAbridged, OpaqueConstructionAbridged, WindowConstructionAbridged, and several materials).  So these models should be simulate-able, albeit in a fully passive manner.

Now that we have these samples, I will begin work on some diagrams that will make the structure of the geometry objects clearer (Rooms, Faces, Shades, Apertures, Doors) .

Lastly, I'll note that, pending some review from @mostaphaRoudsari , it is possible that we make some tweaks to the schema in the coming weeks.  However, the general structure you see in these files has emerged from a lot of discussions and debates over the last few months, meaning we have good reasons for most of the decisions we made and so this general structure is far less likely to change.