### PR TITLE
feat(schedule_samples): Add schema samples for ScheduleRuleset

### DIFF
--- a/app/models/samples/json/schedule_office_occupancy.json
+++ b/app/models/samples/json/schedule_office_occupancy.json
@@ -1,0 +1,190 @@
+{
+    "type": "ScheduleRulesetAbridged",
+    "name": "Large Office Bldg Occ",
+    "default_day_schedule": {
+        "type": "ScheduleDay",
+        "name": "Large Office Bldg Occ_Default",
+        "values": [
+            0.0,
+            0.1,
+            0.2,
+            0.95,
+            0.5,
+            0.95,
+            0.7,
+            0.4,
+            0.1,
+            0.05
+        ],
+        "times": [
+            [
+                0,
+                0
+            ],
+            [
+                6,
+                0
+            ],
+            [
+                7,
+                0
+            ],
+            [
+                8,
+                0
+            ],
+            [
+                12,
+                0
+            ],
+            [
+                13,
+                0
+            ],
+            [
+                17,
+                0
+            ],
+            [
+                18,
+                0
+            ],
+            [
+                20,
+                0
+            ],
+            [
+                22,
+                0
+            ]
+        ],
+        "interpolate": false
+    },
+    "schedule_rules": [
+        {
+            "type": "ScheduleRule",
+            "schedule_day": {
+                "type": "ScheduleDay",
+                "name": "Large Office Bldg Occ_Sat",
+                "values": [
+                    0.0,
+                    0.1,
+                    0.5,
+                    0.1,
+                    0.0
+                ],
+                "times": [
+                    [
+                        0,
+                        0
+                    ],
+                    [
+                        6,
+                        0
+                    ],
+                    [
+                        8,
+                        0
+                    ],
+                    [
+                        14,
+                        0
+                    ],
+                    [
+                        17,
+                        0
+                    ]
+                ],
+                "interpolate": false
+            },
+            "apply_sunday": false,
+            "apply_monday": false,
+            "apply_tuesday": false,
+            "apply_wednesday": false,
+            "apply_thursday": false,
+            "apply_friday": false,
+            "apply_saturday": true,
+            "apply_holiday": false,
+            "start_date": [
+                1,
+                1
+            ],
+            "end_date": [
+                12,
+                31
+            ]
+        },
+        {
+            "type": "ScheduleRule",
+            "schedule_day": {
+                "type": "ScheduleDay",
+                "name": "Large Office Bldg Occ_Sun",
+                "values": [
+                    0.0
+                ],
+                "times": [
+                    [
+                        0,
+                        0
+                    ]
+                ],
+                "interpolate": false
+            },
+            "apply_sunday": true,
+            "apply_monday": false,
+            "apply_tuesday": false,
+            "apply_wednesday": false,
+            "apply_thursday": false,
+            "apply_friday": false,
+            "apply_saturday": false,
+            "apply_holiday": false,
+            "start_date": [
+                1,
+                1
+            ],
+            "end_date": [
+                12,
+                31
+            ]
+        }
+    ],
+    "summer_designday_schedule": {
+        "type": "ScheduleDay",
+        "name": "Large Office Bldg Occ_SmrDsn",
+        "values": [
+            0.0,
+            1.0,
+            0.05
+        ],
+        "times": [
+            [
+                0,
+                0
+            ],
+            [
+                6,
+                0
+            ],
+            [
+                22,
+                0
+            ]
+        ],
+        "interpolate": false
+    },
+    "winter_designday_schedule": {
+        "type": "ScheduleDay",
+        "name": "Large Office Bldg Occ_Sun_WntrDsn",
+        "values": [
+            0.0
+        ],
+        "times": [
+            [
+                0,
+                0
+            ]
+        ],
+        "interpolate": false
+    },
+    "schedule_type_limit": "Fractional"
+}

--- a/app/models/samples/json/schedule_primary_school_occupancy.json
+++ b/app/models/samples/json/schedule_primary_school_occupancy.json
@@ -1,0 +1,183 @@
+{
+    "type": "ScheduleRulesetAbridged",
+    "name": "School Occupancy",
+    "default_day_schedule": {
+        "type": "ScheduleDay",
+        "name": "Weekday School Year",
+        "values": [
+            0.0,
+            1.0,
+            0.5,
+            0.0
+        ],
+        "times": [
+            [
+                0,
+                0
+            ],
+            [
+                8,
+                0
+            ],
+            [
+                15,
+                0
+            ],
+            [
+                18,
+                0
+            ]
+        ],
+        "interpolate": false
+    },
+    "schedule_rules": [
+        {
+            "type": "ScheduleRule",
+            "schedule_day": {
+                "type": "ScheduleDay",
+                "name": "Weekday Summer",
+                "values": [
+                    0.0,
+                    0.5,
+                    0.0
+                ],
+                "times": [
+                    [
+                        0,
+                        0
+                    ],
+                    [
+                        9,
+                        0
+                    ],
+                    [
+                        17,
+                        0
+                    ]
+                ],
+                "interpolate": false
+            },
+            "apply_sunday": false,
+            "apply_monday": true,
+            "apply_tuesday": true,
+            "apply_wednesday": true,
+            "apply_thursday": true,
+            "apply_friday": true,
+            "apply_saturday": false,
+            "apply_holiday": false,
+            "start_date": [
+                7,
+                1
+            ],
+            "end_date": [
+                9,
+                1
+            ]
+        },
+        {
+            "type": "ScheduleRule",
+            "schedule_day": {
+                "type": "ScheduleDay",
+                "name": "Weekend Summer",
+                "values": [
+                    0.0
+                ],
+                "times": [
+                    [
+                        0,
+                        0
+                    ]
+                ],
+                "interpolate": false
+            },
+            "apply_sunday": true,
+            "apply_monday": false,
+            "apply_tuesday": false,
+            "apply_wednesday": false,
+            "apply_thursday": false,
+            "apply_friday": false,
+            "apply_saturday": true,
+            "apply_holiday": true,
+            "start_date": [
+                7,
+                1
+            ],
+            "end_date": [
+                9,
+                1
+            ]
+        },
+        {
+            "type": "ScheduleRule",
+            "schedule_day": {
+                "type": "ScheduleDay",
+                "name": "Weekend School Year",
+                "values": [
+                    0.0
+                ],
+                "times": [
+                    [
+                        0,
+                        0
+                    ]
+                ],
+                "interpolate": false
+            },
+            "apply_sunday": true,
+            "apply_monday": false,
+            "apply_tuesday": false,
+            "apply_wednesday": false,
+            "apply_thursday": false,
+            "apply_friday": false,
+            "apply_saturday": true,
+            "apply_holiday": true,
+            "start_date": [
+                1,
+                1
+            ],
+            "end_date": [
+                12,
+                31
+            ]
+        }
+    ],
+    "summer_designday_schedule": {
+        "type": "ScheduleDay",
+        "name": "School Summer Design",
+        "values": [
+            0.0,
+            1.0,
+            0.25
+        ],
+        "times": [
+            [
+                0,
+                0
+            ],
+            [
+                6,
+                0
+            ],
+            [
+                18,
+                0
+            ]
+        ],
+        "interpolate": false
+    },
+    "winter_designday_schedule": {
+        "type": "ScheduleDay",
+        "name": "School Winter Design",
+        "values": [
+            0.0
+        ],
+        "times": [
+            [
+                0,
+                0
+            ]
+        ],
+        "interpolate": false
+    },
+    "schedule_type_limit": "Fractional"
+}

--- a/app/models/samples/json/schedule_simple_repeating.json
+++ b/app/models/samples/json/schedule_simple_repeating.json
@@ -1,0 +1,38 @@
+{
+    "type": "ScheduleRulesetAbridged",
+    "name": "Simple Repeating",
+    "default_day_schedule": {
+        "type": "ScheduleDay",
+        "name": "Simple Repeating_Day Schedule",
+        "values": [
+            0.5,
+            1.0,
+            0.5,
+            1.0,
+            0.5
+        ],
+        "times": [
+            [
+                0,
+                0
+            ],
+            [
+                6,
+                0
+            ],
+            [
+                12,
+                0
+            ],
+            [
+                16,
+                0
+            ],
+            [
+                20,
+                0
+            ]
+        ],
+        "interpolate": false
+    }
+}

--- a/app/models/samples/json/scheduletypelimit_temperature.json
+++ b/app/models/samples/json/scheduletypelimit_temperature.json
@@ -1,0 +1,8 @@
+{
+    "type": "ScheduleTypeLimit",
+    "name": "Temperature",
+    "lower_limit": -273.15,
+    "upper_limit": null,
+    "numeric_type": "Continuous",
+    "unit_type": "Temperature"
+}


### PR DESCRIPTION
@tanushree04 ,

You can see some samples for the updated shemas of `ScheduleRuleset`, `ScheduleRule`, `ScheduleDay`, and `ScheduleTypeLimit` in this PR.  These follow all of the conventions of the recent 9 issues that I opened.

Also note that all of these objects can remain non-abridged with the exception of `ScheduleRuleset`, which is being changed over to be `Abridged` so that the `ScheduleTypeLimit` object can just be referenced by name and not by a full dictionary.

One detail to note, which may require some extra checks in the energy-model-measure, is that the schema of `ScheduleRulesetAbridged` may repeat a certain `ScheduleDay` if it appears both in a summer/winter design day as well as in the schedule rules or default day schedule.  So the measure might need to do an internal check to see if this is a case of a duplicated ScheduleDay and then write one one into the osm.  If anyone has better suggestions for how to deal with this, I am certainly open to them but the intensity of this check seems low enough and the value of being able to nest ScheduleDay under the schedule rules high enough that I am ok with this solution.